### PR TITLE
Installs @types/node ^12.12.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "12.12.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
+      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ws": "^1.0.1"
   },
   "devDependencies": {
+    "@types/node": "^12.12.21",
     "coveralls": "^2.11.9",
     "dotenv": "^2.0.0",
     "espower-typescript": "^5.0.1",


### PR DESCRIPTION
Fixes compiler warnings:

```
Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.ts(2580)
```